### PR TITLE
Feat/improve logging

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1875,7 +1875,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "actix",
  "actix-broker",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Sulaiman AlRomaih"]
 license = "GPL-3"

--- a/server/src/actor.rs
+++ b/server/src/actor.rs
@@ -20,11 +20,12 @@ impl Actor for WsChatSession {
     fn started(&mut self, ctx: &mut Self::Context) {
         self.id = rand::random::<usize>();
         log::debug!(
-            "[Websocket] Session started for {} with ID {}",
+            target: "Websocket",
+            "Session started for {} with ID {}",
             self.name,
             self.id
         );
-        log::debug!("[Websocket] Auto-join is set to: {}", self.auto_join);
+        log::debug!(target: "Websocket","Auto-join is set to: {}", self.auto_join);
 
         self.last_heartbeat = Some(Instant::now());
         self.start_heartbeat(ctx);
@@ -36,18 +37,20 @@ impl Actor for WsChatSession {
 
     fn stopped(&mut self, _ctx: &mut Self::Context) {
         log::debug!(
-            "[Websocket] WsChatSession closed for {}({}) in room {}",
+            target: "Websocket",
+            "WsChatSession closed for {}({}) in room {}",
             self.name.clone(),
             self.id,
             self.room
         );
 
         if let Ok(uuid) = Uuid::parse_str(&self.session_id) {
-            log::debug!("[Websocket] Removing client {} from session", uuid);
+            log::debug!(target: "Websocket","Removing client {} from session", uuid);
             self.session_store.remove_client(&uuid);
         } else {
             log::debug!(
-                "[Websocket] Invalid UUID format for session_id: {}",
+                target: "Websocket",
+                "Invalid UUID format for session_id: {}",
                 self.session_id
             );
         }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -23,7 +23,8 @@ impl ServerConfig {
     pub fn load(auto_join_override: Option<bool>) -> Result<Self, ConfigError> {
         let environment = env::var("RUN_ENV").unwrap_or_else(|_| "development".to_string());
         log::debug!(
-            "[Websocket] Loading configuration for environment: {}",
+            target: "Websocket",
+            "Loading configuration for environment: {}",
             environment
         );
 

--- a/server/src/handler.rs
+++ b/server/src/handler.rs
@@ -32,7 +32,8 @@ impl Handler<LeaveRoom> for WsChatServer {
                 if room.is_empty() && msg.1 != "main" {
                     rooms.remove(&msg.1);
                     log::debug!(
-                        "[Websocket] Room '{}' removed from session {}",
+                        target: "Websocket",
+                        "Room '{}' removed from session {}",
                         msg.1,
                         msg.0
                     );
@@ -42,7 +43,8 @@ impl Handler<LeaveRoom> for WsChatServer {
                 if all_empty {
                     self.rooms.remove(&msg.0);
                     log::debug!(
-                        "[Websocket] All rooms in session {} are empty, removing session",
+                        target: "Websocket",
+                        "All rooms in session {} are empty, removing session",
                         msg.0
                     );
                 } else {
@@ -53,7 +55,8 @@ impl Handler<LeaveRoom> for WsChatServer {
                 self.broadcast_room_members(&msg.0, &msg.1);
 
                 log::debug!(
-                    "[Websocket] User {} in {} left room {}. Rooms: {:?}",
+                    target: "Websocket",
+                    "User {} in {} left room {}. Rooms: {:?}",
                     msg.2,
                     msg.0,
                     msg.1,
@@ -97,7 +100,8 @@ impl Handler<RelaySignalMessage> for WsChatServer {
 
         if from == to {
             log::debug!(
-                "[Websocket] Skipping self-to-self signal from '{}' to '{}'",
+                target: "Websocket",
+                "Skipping self-to-self signal from '{}' to '{}'",
                 from,
                 to
             );
@@ -122,7 +126,7 @@ impl Handler<CleanupSession> for WsChatServer {
 
     fn handle(&mut self, msg: CleanupSession, _ctx: &mut Self::Context) -> Self::Result {
         if self.rooms.contains_key(&msg.0) {
-            log::debug!("[Websocket] Removing session {} from rooms", msg.0);
+            log::debug!(target: "Websocket","Removing session {} from rooms", msg.0);
             self.rooms.remove(&msg.0);
         }
     }
@@ -136,7 +140,8 @@ impl Handler<ValidateAndRelaySignal> for WsChatServer {
 
         if !shared_room {
             log::warn!(
-                "[Websocket] Attempted signal to user not in same room: {} -> {}",
+                target: "Websocket",
+                "Attempted signal to user not in same room: {} -> {}",
                 msg.from_user,
                 msg.to_user
             );

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -21,10 +21,11 @@ async fn main() -> Result<()> {
         .finish()
         .expect("Invalid rate limit configuration");
 
-    log::debug!("Rate limiting configured: {:?}", governor_conf);
+    log::debug!(target: "Websocket", "Rate limiting configured: {:?}", governor_conf);
 
     log::info!(
-        "[Websocket] Starting HTTPS server at https://{} - PastePoint({}) - {} - {}",
+        target: "Websocket",
+        "Starting HTTPS server at https://{} - PastePoint({}) - {} - {}",
         config.bind_address,
         NAME,
         VERSION,
@@ -34,15 +35,17 @@ async fn main() -> Result<()> {
     let mut builder = SslAcceptor::mozilla_intermediate(SslMethod::tls())?;
     builder
         .set_private_key_file(&config.key_file_path, SslFiletype::PEM)
-        .map_err(|e| log::error!("[Websocket] Failed to load private key: {}", e))
+        .map_err(|e| log::error!(target: "Websocket","Failed to load private key: {}", e))
         .expect("Cannot find private key file");
     builder
         .set_certificate_chain_file(&config.cert_file_path)
-        .map_err(|e| log::error!("[Websocket] Failed to load certificate chain file: {}", e))
+        .map_err(
+            |e| log::error!(target: "Websocket","Failed to load certificate chain file: {}", e),
+        )
         .expect("Cannot find certificate chain file");
 
-    log::debug!("[Websocket] Using key file: {}", &config.key_file_path);
-    log::debug!("[Websocket] Using cert file: {}", &config.cert_file_path);
+    log::debug!(target: "Websocket","Using key file: {}", &config.key_file_path);
+    log::debug!(target: "Websocket","Using cert file: {}", &config.cert_file_path);
 
     let session_manager = Data::new(SessionStore::default());
     let server_config = Data::new(config.clone());

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -24,7 +24,8 @@ pub async fn create_session(store: web::Data<SessionStore>) -> impl Responder {
             Ok(guard) => guard,
             Err(e) => {
                 log::error!(
-                    "[Websocket] Failed to acquire lock on key_to_session: {:?}",
+                    target: "Websocket",
+                    "Failed to acquire lock on key_to_session: {:?}",
                     e
                 );
                 return Err(ServerError::InternalServerError);
@@ -53,11 +54,11 @@ pub async fn chat_ws(
 ) -> Result<HttpResponse, Error> {
     if let Some(peer) = req.peer_addr() {
         let ip_str = peer.ip().to_string();
-        log::debug!("[Websocket] Peer IP: {}", ip_str);
+        log::debug!(target: "Websocket","Peer IP: {}", ip_str);
 
         store.start_websocket(config.get_ref(), &req, stream, &ip_str, false, false)
     } else {
-        log::debug!("[Websocket] No Public IP address found!");
+        log::debug!(target: "Websocket","No Public IP address found!");
         Ok(HttpResponse::BadRequest().body("No Public IP Address found"))
     }
 }
@@ -74,9 +75,9 @@ pub async fn private_chat_ws(
     config: web::Data<ServerConfig>,
 ) -> Result<HttpResponse, Error> {
     let code = path.into_inner();
-    log::debug!("[Websocket] Received session code: {}", code);
+    log::debug!(target: "Websocket", "Received session code: {}", code);
     if code.trim().is_empty() {
-        log::debug!("[Websocket] Empty code => returning 400");
+        log::debug!(target: "Websocket", "Empty code => returning 400");
         return Ok(HttpResponse::BadRequest().body("Session code cannot be empty"));
     }
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -10,7 +10,7 @@ use std::{
 
 impl WsChatServer {
     pub fn take_room(&mut self, session_id: &str, room_name: &str) -> Option<Room> {
-        log::debug!("[Websocket] Getting room: {}", room_name);
+        log::debug!(target: "Websocket","Getting room: {}", room_name);
         let session_id = self.rooms.get_mut(session_id)?;
         let room = session_id.get_mut(room_name)?;
         let room = std::mem::take(room);
@@ -30,7 +30,7 @@ impl WsChatServer {
         if let Some(room) = self.rooms.get_mut(session_id) {
             if let Some(existing_room) = room.get_mut(room_name) {
                 return if let Vacant(e) = existing_room.entry(id) {
-                    log::debug!("[Websocket] Adding client to room: {}", room_name);
+                    log::debug!(target: "Websocket", "Adding client to room: {}", room_name);
                     e.insert(ClientMetadata {
                         recipient: client,
                         name,
@@ -38,7 +38,8 @@ impl WsChatServer {
                     id
                 } else {
                     log::debug!(
-                        "[Websocket] Client {} already in room: {}, skipping addition",
+                        target: "Websocket",
+                        "Client {} already in room: {}, skipping addition",
                         id,
                         room_name
                     );
@@ -73,7 +74,8 @@ impl WsChatServer {
         _src: usize,
     ) -> Option<()> {
         log::debug!(
-            "[Websocket] Sending join message to room {}: {}",
+            target: "Websocket",
+            "Sending join message to room {}: {}",
             room_name,
             msg
         );
@@ -89,13 +91,15 @@ impl WsChatServer {
                         .is_ok()
                     {
                         log::debug!(
-                            "[Websocket] Join Message sent to client {}, staying in room: {}",
+                            target: "Websocket",
+                            "Join Message sent to client {}, staying in room: {}",
                             id,
                             room_name
                         );
                     } else {
                         log::debug!(
-                            "[Websocket] Failed to send join message to client {}, removing from room: {}",
+                            target: "Websocket",
+                            "Failed to send join message to client {}, removing from room: {}",
                             id,
                             room_name
                         );
@@ -107,7 +111,8 @@ impl WsChatServer {
             Some(())
         } else {
             log::debug!(
-                "[Websocket] Room {} not found in session {}",
+                target: "Websocket",
+                "Room {} not found in session {}",
                 room_name,
                 session_id
             );
@@ -136,7 +141,8 @@ impl WsChatServer {
                     .map(|client_metadata| client_metadata.name.clone())
                     .collect();
                 log::debug!(
-                    "[Websocket] Broadcasting members of room {}: {:?}",
+                    target: "Websocket",
+                    "Broadcasting members of room {}: {:?}",
                     room_name,
                     member_list
                 );
@@ -159,7 +165,8 @@ impl WsChatServer {
             if total_users == 0 {
                 self.rooms.remove(session_id);
                 log::debug!(
-                    "[Websocket] Session {} has no more users and is being removed",
+                    target: "Websocket",
+                    "Session {} has no more users and is being removed",
                     session_id
                 );
             }
@@ -198,12 +205,13 @@ impl WsChatServer {
             .collect();
 
         for session_id in empty_sessions {
-            log::debug!("[Websocket] Cleanup: Removing empty session {}", session_id);
+            log::debug!(target: "Websocket","Cleanup: Removing empty session {}", session_id);
             self.rooms.remove(&session_id);
         }
 
         log::debug!(
-            "[Websocket] Current server state: {} active sessions",
+            target: "Websocket",
+            "Current server state: {} active sessions",
             self.rooms.len()
         );
     }
@@ -230,14 +238,16 @@ impl WsChatServer {
                         // try_send returns a Result
                         if let Err(e) = client.recipient.try_send(message) {
                             log::error!(
-                                "[Websocket] Failed to relay signal from {} to {}: {:?}",
+                                target: "Websocket",
+                                "Failed to relay signal from {} to {}: {:?}",
                                 from_user,
                                 to_user,
                                 e
                             );
                         } else {
                             log::debug!(
-                                "[Websocket] Successfully relayed signal from {} to {}",
+                                target: "Websocket",
+                                "Successfully relayed signal from {} to {}",
                                 from_user,
                                 to_user
                             );
@@ -249,7 +259,8 @@ impl WsChatServer {
         }
 
         log::debug!(
-            "[Websocket] Could not find target user {} to relay message from {}",
+            target: "Websocket",
+            "Could not find target user {} to relay message from {}",
             to_user,
             from_user
         );
@@ -258,12 +269,12 @@ impl WsChatServer {
 
 impl SystemService for WsChatServer {
     fn service_started(&mut self, _ctx: &mut Context<Self>) {
-        log::info!("[Websocket] WsChatServer started");
+        log::info!(target: "Websocket","WsChatServer started");
     }
 }
 
 impl Supervised for WsChatServer {
     fn restarting(&mut self, _ctx: &mut Context<Self>) {
-        log::info!("[Websocket] WsChatServer restarting");
+        log::info!(target: "Websocket","WsChatServer restarting");
     }
 }

--- a/server/src/session.rs
+++ b/server/src/session.rs
@@ -32,7 +32,8 @@ impl WsChatSession {
     pub fn join_room(&mut self, room_name: &str, ctx: &mut ws::WebsocketContext<Self>) {
         if self.room == room_name {
             log::debug!(
-                "[Websocket] User '{}' is already in room '{}'. Skipping join.",
+                target: "Websocket",
+                "User '{}' is already in room '{}'. Skipping join.",
                 self.name,
                 room_name
             );
@@ -58,7 +59,8 @@ impl WsChatSession {
             .then(|id, act, _ctx| {
                 if let Ok(id) = id {
                     log::debug!(
-                        "[Websocket] {} successfully joined room '{}'",
+                        target: "Websocket",
+                        "{} successfully joined room '{}'",
                         act.session_id,
                         &room_name
                     );
@@ -78,7 +80,7 @@ impl WsChatSession {
             .into_actor(self)
             .then(|res, _, ctx| {
                 if let Ok(rooms) = res {
-                    log::debug!("[Websocket] [SystemRooms] Rooms Available: {:?}", rooms);
+                    log::debug!(target: "Websocket", "[SystemRooms] Rooms Available: {:?}", rooms);
 
                     let room_list = rooms.join(", ");
                     ctx.text(format!("[SystemRooms] {}", room_list));
@@ -92,30 +94,30 @@ impl WsChatSession {
 
     fn user_command(&mut self, command_str: &str, ctx: &mut ws::WebsocketContext<WsChatSession>) {
         let command_str = command_str.trim();
-        log::debug!("[Websocket] Processing command: '{}'", command_str);
+        log::debug!(target: "Websocket","Processing command: '{}'", command_str);
 
         let mut parts = command_str.splitn(2, ' ');
         let cmd = parts.next().unwrap_or("");
         let args = parts.next();
         match cmd {
             "/list" => {
-                log::debug!("[Websocket] Received list command");
+                log::debug!(target: "Websocket","Received list command");
                 self.list_rooms(ctx);
             }
             "/join" => {
                 if let Some(room_name) = args {
-                    log::debug!("[Websocket] Received join command for room '{}'", room_name);
+                    log::debug!(target: "Websocket", "Received join command for room '{}'", room_name);
                     self.join_room(room_name, ctx);
                 } else {
                     ctx.text("[SystemError] Room name is required");
                 }
             }
             "/name" => {
-                log::debug!("[Websocket] Received name command");
+                log::debug!(target: "Websocket","Received name command");
                 ctx.text(format!("[SystemName] {}", self.name));
             }
             _ => {
-                log::debug!("[Websocket] Unknown command: '{}'", cmd);
+                log::debug!(target: "Websocket", "Unknown command: '{}'", cmd);
                 ctx.text(format!(
                     "[SystemError] Error Unknown command: {}",
                     ServerError::NotFound
@@ -128,7 +130,8 @@ impl WsChatSession {
         // 1. Size validation
         if msg.len() > MAX_SIGNAL_SIZE {
             log::warn!(
-                "[Websocket] Oversized signaling message ({} bytes) from user {}",
+                target: "Websocket",
+                "Oversize signaling message ({} bytes) from user {}",
                 msg.len(),
                 self.name
             );
@@ -141,7 +144,7 @@ impl WsChatSession {
         let value = match serde_json::from_str::<Value>(payload) {
             Ok(v) => v,
             Err(e) => {
-                log::warn!("[Websocket] Invalid signal JSON from {}: {}", self.name, e);
+                log::warn!(target: "Websocket", "Invalid signal JSON from {}: {}", self.name, e);
                 ctx.text("[SystemError] Invalid signaling message format");
                 return;
             }
@@ -151,7 +154,7 @@ impl WsChatSession {
         let to_user = match value.get("to").and_then(|v| v.as_str()) {
             Some(user) => user,
             None => {
-                log::warn!("[Websocket] Signal missing 'to' field from {}", self.name);
+                log::warn!(target: "Websocket", "Signal missing 'to' field from {}", self.name);
                 ctx.text("[SystemError] Signaling message missing 'to' field");
                 return;
             }
@@ -169,7 +172,7 @@ impl WsChatSession {
     fn handle_user_disconnect(&self) {
         let leave_msg = LeaveRoom(self.session_id.clone(), self.room.clone(), self.id);
         self.issue_system_async(leave_msg);
-        log::debug!("[Websocket] User {} disconnected", self.name);
+        log::debug!(target: "Websocket", "User {} disconnected", self.name);
     }
 
     pub fn start_heartbeat(&self, ctx: &mut ws::WebsocketContext<Self>) {
@@ -177,7 +180,8 @@ impl WsChatSession {
             if let Some(last) = act.last_heartbeat {
                 if Instant::now().duration_since(last) > Duration::from_secs(40) {
                     log::debug!(
-                        "[Websocket] Heartbeat failed for user {}, disconnecting!",
+                        target: "Websocket",
+                        "Heartbeat failed for user {}, disconnecting!",
                         act.name
                     );
                     act.handle_user_disconnect();
@@ -185,7 +189,7 @@ impl WsChatSession {
                     return;
                 }
             }
-            log::debug!("[Websocket] Sending heartbeat to user {}", act.name);
+            log::debug!(target: "Websocket", "Sending heartbeat to user {}", act.name);
             ctx.ping(b"");
         });
     }
@@ -208,21 +212,22 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsChatSession {
         match msg {
             ws::Message::Text(text) => {
                 let msg = text.trim();
-                log::debug!("[Websocket] Received message: '{}'", msg);
+                log::debug!(target: "Websocket", "Received message: '{}'", msg);
                 if msg.starts_with("[SignalMessage]") {
                     self.handle_signal_message(msg, ctx);
                 } else if msg.starts_with("[UserCommand]") {
                     let command_str = msg.trim_start_matches("[UserCommand]").trim();
                     log::debug!(
-                        "[Websocket] Command string after trimming: '{}'",
+                        target: "Websocket",
+                        "Command string after trimming: '{}'",
                         command_str
                     );
                     self.user_command(command_str, ctx);
                 } else if msg.starts_with("[UserDisconnected]") {
-                    log::debug!("[Websocket] Received disconnect command");
+                    log::debug!(target: "Websocket","Received disconnect command");
                     self.handle_user_disconnect();
                 } else {
-                    log::debug!("[Websocket] Unknown command: {}", msg);
+                    log::debug!(target: "Websocket","Unknown command: {}", msg);
                     ctx.text(format!(
                         "[SystemError] Error Unknown command: {}",
                         ServerError::NotFound
@@ -230,16 +235,16 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsChatSession {
                 }
             }
             ws::Message::Ping(msg) => {
-                log::debug!("[Websocket] Received ping message");
+                log::debug!(target: "Websocket", "Received ping message");
                 self.last_heartbeat = Some(Instant::now());
                 ctx.pong(&msg);
             }
             ws::Message::Pong(_) => {
-                log::debug!("[Websocket] Received pong message");
+                log::debug!(target: "Websocket", "Received pong message");
                 self.last_heartbeat = Some(Instant::now());
             }
             ws::Message::Close(reason) => {
-                log::debug!("[Websocket] Closing connection: {:?}", reason);
+                log::debug!(target: "Websocket", "Closing connection: {:?}", reason);
                 self.handle_user_disconnect();
                 ctx.close(reason);
                 ctx.stop();


### PR DESCRIPTION
This pull request includes a version bump and several changes to improve logging in the WebSocket server. The most important changes involve updating the logging format to include a target for better log categorization.

### Version Update:
* [`server/Cargo.toml`](diffhunk://#diff-36a55fca956d2696a4fb89bc9847360169a01e70aa29641862a78ca833e9becfL3-R3): Bumped the version from `0.5.0` to `0.5.1`.

### Logging Enhancements:
* Updated log statements across multiple files to include the `target: "Websocket"` parameter for better log categorization:
  * [`server/src/actor.rs`](diffhunk://#diff-1628900007956367ea796dfab343d3d8fdaadbdecf7eda15c66248bc12d3685cL23-R28): Modified log statements in `impl Actor for WsChatSession`. [[1]](diffhunk://#diff-1628900007956367ea796dfab343d3d8fdaadbdecf7eda15c66248bc12d3685cL23-R28) [[2]](diffhunk://#diff-1628900007956367ea796dfab343d3d8fdaadbdecf7eda15c66248bc12d3685cL39-R53)
  * [`server/src/config.rs`](diffhunk://#diff-7aec9b0ac22ce91dcf09989df83d30183914594644ba39fbff381977a4558b76L26-R27): Updated log statement in `impl ServerConfig`.
  * [`server/src/handler.rs`](diffhunk://#diff-ff4b69568102786752794dcc8b8fa055dc5cef848a93cebde0a996af024256dbL35-R36): Enhanced log statements in various handlers. [[1]](diffhunk://#diff-ff4b69568102786752794dcc8b8fa055dc5cef848a93cebde0a996af024256dbL35-R36) [[2]](diffhunk://#diff-ff4b69568102786752794dcc8b8fa055dc5cef848a93cebde0a996af024256dbL45-R47) [[3]](diffhunk://#diff-ff4b69568102786752794dcc8b8fa055dc5cef848a93cebde0a996af024256dbL56-R59) [[4]](diffhunk://#diff-ff4b69568102786752794dcc8b8fa055dc5cef848a93cebde0a996af024256dbL100-R104) [[5]](diffhunk://#diff-ff4b69568102786752794dcc8b8fa055dc5cef848a93cebde0a996af024256dbL125-R129) [[6]](diffhunk://#diff-ff4b69568102786752794dcc8b8fa055dc5cef848a93cebde0a996af024256dbL139-R144)
  * [`server/src/main.rs`](diffhunk://#diff-01fd5002f7585d6f2b853a8c83e6c0a1acb2b16b6e6f8f581fb3365377d331bcL24-R28): Improved log statements in the main function. [[1]](diffhunk://#diff-01fd5002f7585d6f2b853a8c83e6c0a1acb2b16b6e6f8f581fb3365377d331bcL24-R28) [[2]](diffhunk://#diff-01fd5002f7585d6f2b853a8c83e6c0a1acb2b16b6e6f8f581fb3365377d331bcL37-R48)
  * [`server/src/routes.rs`](diffhunk://#diff-c9e0690e8f2cc0fcfb723abb12bc8ba62362842d6c3a1adc526838a2b6d814fbL27-R28): Enhanced log statements in route handlers. [[1]](diffhunk://#diff-c9e0690e8f2cc0fcfb723abb12bc8ba62362842d6c3a1adc526838a2b6d814fbL27-R28) [[2]](diffhunk://#diff-c9e0690e8f2cc0fcfb723abb12bc8ba62362842d6c3a1adc526838a2b6d814fbL56-R61) [[3]](diffhunk://#diff-c9e0690e8f2cc0fcfb723abb12bc8ba62362842d6c3a1adc526838a2b6d814fbL77-R80)
  * [`server/src/server.rs`](diffhunk://#diff-e4e539f1719bacc61407b3ccd49ec44b594e30e2509f6a76bba6e65c4387e40bL13-R13): Updated log statements in `impl WsChatServer`. [[1]](diffhunk://#diff-e4e539f1719bacc61407b3ccd49ec44b594e30e2509f6a76bba6e65c4387e40bL13-R13) [[2]](diffhunk://#diff-e4e539f1719bacc61407b3ccd49ec44b594e30e2509f6a76bba6e65c4387e40bL33-R42) [[3]](diffhunk://#diff-e4e539f1719bacc61407b3ccd49ec44b594e30e2509f6a76bba6e65c4387e40bL76-R78) [[4]](diffhunk://#diff-e4e539f1719bacc61407b3ccd49ec44b594e30e2509f6a76bba6e65c4387e40bL92-R102) [[5]](diffhunk://#diff-e4e539f1719bacc61407b3ccd49ec44b594e30e2509f6a76bba6e65c4387e40bL110-R115) [[6]](diffhunk://#diff-e4e539f1719bacc61407b3ccd49ec44b594e30e2509f6a76bba6e65c4387e40bL139-R145) [[7]](diffhunk://#diff-e4e539f1719bacc61407b3ccd49ec44b594e30e2509f6a76bba6e65c4387e40bL162-R169) [[8]](diffhunk://#diff-e4e539f1719bacc61407b3ccd49ec44b594e30e2509f6a76bba6e65c4387e40bL201-R214) [[9]](diffhunk://#diff-e4e539f1719bacc61407b3ccd49ec44b594e30e2509f6a76bba6e65c4387e40bL233-R250) [[10]](diffhunk://#diff-e4e539f1719bacc61407b3ccd49ec44b594e30e2509f6a76bba6e65c4387e40bL252-R263) [[11]](diffhunk://#diff-e4e539f1719bacc61407b3ccd49ec44b594e30e2509f6a76bba6e65c4387e40bL261-R278)
  * [`server/src/session.rs`](diffhunk://#diff-a69d8ee558fd81c0e447f4bfc1ee5aeb1a131d3d66e958e260f59a9f1b265bafL35-R36): Modified log statements in `impl WsChatSession`. [[1]](diffhunk://#diff-a69d8ee558fd81c0e447f4bfc1ee5aeb1a131d3d66e958e260f59a9f1b265bafL35-R36) [[2]](diffhunk://#diff-a69d8ee558fd81c0e447f4bfc1ee5aeb1a131d3d66e958e260f59a9f1b265bafL61-R63) [[3]](diffhunk://#diff-a69d8ee558fd81c0e447f4bfc1ee5aeb1a131d3d66e958e260f59a9f1b265bafL81-R83)