### PR TITLE
Client: Enhancements in Docker and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,13 @@
 # Production environment (default)
 prod:
 	@echo "Starting production environment..."
-	docker compose up -d
+	docker compose up --build --force-recreate -d
 	@echo "Production services are starting. View logs with: make logs"
 
 # Development environment
 dev:
 	@echo "Starting development environment..."
-	docker compose --env-file .env.development up --build -d
+	docker compose --env-file .env.development up --build --force-recreate -d
 	@echo "Development services are starting. View logs with: make logs"
 
 # Stop all containers

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -23,6 +23,12 @@ COPY --from=builder /usr/src/app/dist/client/browser /usr/share/nginx/html/brows
 COPY nginx/nginx.conf /etc/nginx/conf.d/default.conf.template
 COPY nginx/security-headers.conf /etc/nginx/security-headers.conf
 
+# Copy the entrypoint script and make it executable
+COPY docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh && \
+    chown nginx:nginx /docker-entrypoint.sh && \
+    chown nginx:nginx /etc/nginx/conf.d/default.conf.template
+
 # Create directories and set appropriate permissions for the nginx user
 RUN mkdir -p /var/cache/nginx/client_temp /var/run/nginx /var/log/nginx && \
     touch /var/run/nginx.pid && \
@@ -41,8 +47,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 RUN chown -R nginx:nginx /etc/nginx/conf.d
 USER nginx
 
-# Copy the entrypoint script
-COPY docker-entrypoint.sh /
+# Set environment variables for NGINX
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       context: .
       dockerfile: server/Dockerfile
       args:
-        RUST_BUILD_MODE: ${RUST_BUILD_MODE}
+        RUST_BUILD_MODE: ${RUST_BUILD_MODE:-release}
     ports:
       - "9000:9000"
     environment:
@@ -39,7 +39,7 @@ services:
       context: .
       dockerfile: client/Dockerfile
       args:
-        NPM_BUILD_CONFIG: ${NPM_BUILD_CONFIG}
+        NPM_BUILD_CONFIG: ${NPM_BUILD_CONFIG:-docker}
     environment:
       SERVER_NAME: ${SERVER_NAME:-pastepoint.com www.pastepoint.com}
       SSL_CERT_PATH: ${SSL_CERT_PATH:-/etc/ssl/pastepoint/cert.pem}

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -42,6 +42,11 @@ impl ServerConfig {
 
     pub fn is_dev_env() -> bool {
         let environment = env::var("RUN_ENV").unwrap_or_else(|_| "development".to_string());
+        log::debug!(
+            target: "Websocket",
+            "Checking if environment is development: {}",
+            environment
+        );
         environment == "development" || environment == "docker-dev"
     }
 }


### PR DESCRIPTION
- Set default values for RUST_BUILD_MODE and NPM_BUILD_CONFIG in docker-compose.yml, providing better fallbacks.
- Modified 'docker compose up' commands in Makefile to include '--build --force-recreate', ensuring fresh builds on startup.
- Added debug log message in server/src/config.rs to check if environment is development, aiding debugging process.
- Adjust the permission for docker-entrypoint.sh.