### PR TITLE
Nginx: Added HTTP support and health check endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       SSL_CERT_KEY_PATH: ${SSL_CERT_KEY_PATH:-/etc/ssl/pastepoint/key.pem}
     ports:
       - "443:443"
+      - "80:80"
     volumes:
       - ${CERT_PATH:-/etc/ssl/pastepoint}:/etc/ssl/${CERT_MOUNT:-pastepoint}:ro
     depends_on:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -99,6 +99,16 @@ server {
 
 server {
     listen 80;
-    server_name ${SERVER_NAME};
-    return 301 https://$host$request_uri;
+    server_name _;
+
+    # Health check endpoint
+    location /health {
+        return 200 'OK';
+        add_header Content-Type text/plain;
+    }
+
+    # Redirect everything else to HTTPS
+    location / {
+        return 301 https://$host$request_uri;
+    }
 }


### PR DESCRIPTION
- Introduced port 80 in the docker-compose file to enable HTTP support.
- Implemented a new health check endpoint at /health on port 80, which returns a 200 status code with 'OK' message.
- All other requests on port 80 are now redirected to HTTPS for secure communication.