### PR TITLE
Add legal disclaimer

### DIFF
--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,0 +1,106 @@
+# PastePoint – Legal Disclaimer
+
+## Introduction
+
+This document outlines the legal disclaimer for the use of **PastePoint**, a peer-to-peer file sharing and messaging platform focused on privacy, speed, and local connectivity. By using PastePoint, you agree to the terms outlined below. If you do not agree with these terms, please discontinue use.
+
+
+## 1. No Warranty
+
+PastePoint is provided “as is,” without any warranty of any kind, express or implied. This includes, but is not limited to, warranties of merchantability, fitness for a particular purpose, and non-infringement.
+
+The developers make no guarantees about the reliability, availability, or security of the service.
+
+
+## 2. Limitation of Liability
+
+Under no circumstances shall the creators, maintainers, or contributors of PastePoint be held liable for any damages or claims resulting from the use or misuse of this software, including but not limited to:
+
+- Loss of data
+- Data breaches
+- Transmission of malware or illegal content
+- Service disruptions or data corruption
+
+Users accept full responsibility for their actions and content shared via PastePoint.
+
+
+## 3. Intended Use
+
+PastePoint is designed for:
+
+- Secure, **local network** usage
+- **Peer-to-peer** file transfers and messaging
+- Usage in compliance with all applicable laws
+
+It is **not recommended** for use over public or untrusted networks unless you fully understand and accept the associated risks.
+
+
+## 4. User Responsibility
+
+By using PastePoint, you agree to:
+
+- Use it lawfully and ethically
+- Avoid transferring copyrighted, illegal, or harmful material
+- Secure your environment (network, browser, and machine)
+
+The developers are not responsible for monitoring or controlling user activity.
+
+
+## 5. No Data Retention
+
+PastePoint does **not** store:
+
+- Files
+- Messages
+- Metadata
+- IP logs or session history
+
+All file transfers occur directly and are ephemeral. However, your device, browser, or network may log information independently.
+
+
+## 6. Encryption & Security
+
+PastePoint uses:
+
+- **WebRTC** for end-to-end encrypted P2P transfers
+- **WebSocket** signaling with optional TLS via Nginx
+- **SSL/TLS**
+
+Security is a shared responsibility between the app and the user. For sensitive usage, use trusted certificates and ensure your host system is secure.
+
+
+## 7. Open Source Licensing
+
+PastePoint uses and integrates third-party open-source software. Each component is governed by its own license (e.g., MIT, Apache, GPL).
+
+The main project is released under the **GPL-3.0** license. Refer to the [LICENSE](LICENSE) file for more.
+
+
+## 8. Contributions
+
+By contributing, you agree to:
+
+- License your code under the same license as PastePoint
+- Avoid submitting malicious or unauthorized content
+- Follow the project’s code quality and community standards
+
+
+## 9. Production Use Notice
+
+PastePoint is under active development and is primarily intended for local or experimental use. Production deployments should:
+
+- Replace self-signed certs with valid CA certificates
+- Harden the Nginx config and rate limits
+- Regularly audit code and dependencies
+- Use isolated network setups if handling sensitive files
+
+
+## 10. Contact
+
+For security concerns, legal questions, or bug reports:
+
+- GitHub Issues: [https://github.com/SloMR/pastepoint/issues](https://github.com/SloMR/pastepoint/issues)
+- Email: [sulaimanromaih@gmail.com](mailto:sulaimanromaih@gmail.com)
+
+
+PastePoint is a tool. Please use it wisely, lawfully, and responsibly.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ PastePoint is a secure, feature-rich file-sharing service designed for local net
 [![GPL-3.0 License](https://img.shields.io/github/license/SloMR/pastepoint)](LICENSE)
 [![Open Issues](https://img.shields.io/github/issues/SloMR/pastepoint)](https://github.com/SloMR/pastepoint/issues)
 
----
-
 ## 🌟 Features
 
 ### Core Features:
@@ -51,8 +49,6 @@ PastePoint is a secure, feature-rich file-sharing service designed for local net
 - 📦 Response compression for faster page loads
 - 🎯 Static asset optimization with proper caching headers
 
----
-
 ## 🛠️ Tech Stack
 
 ### **Backend** (Rust)
@@ -86,8 +82,6 @@ PastePoint is a secure, feature-rich file-sharing service designed for local net
 - **SSL/TLS**: Automated certificate management
 - **Health Monitoring**: Built-in health check endpoints
 - **SSR Server**: Express.js with compression middleware
-
----
 
 ## Directory Structure
 
@@ -136,8 +130,6 @@ pastepoint/
 - `nginx/security_headers.conf`: Security headers configuration
 - `nginx/locations.conf`: Location block configurations including SEO routes
 - `nginx/ssl.conf`: SSL/TLS settings
-
----
 
 ## 🔧 Development Guide
 
@@ -257,8 +249,6 @@ pastepoint/
 - **Frontend**:
   - `client/src/environments/*`: Update environment variables for development and production.
 
----
-
 ## 🚨 Troubleshooting
 
 **Common Issues**:
@@ -279,8 +269,6 @@ pastepoint/
    - Verify Express server is running on the configured port
    - Check Nginx configuration for proper proxy to SSR service
 
----
-
 ## 🤝 Contributing
 
 **We welcome contributions! Please follow these steps**:
@@ -299,13 +287,13 @@ pastepoint/
 - **Angular**: Adhere to provided `.prettierrc` and `eslint` rules
 - **Tests**: Maintain 80%+ coverage
 
----
-
 ## 📜 License
 
 This project is licensed under the GPL-3.0 License. See the [LICENSE](LICENSE) file for details.
 
----
+## ⚠️ Usage Disclaimer
+
+- [📜 Disclaimer](DISCLAIMER.md)
 
 ## 📬 Contact
 
@@ -313,8 +301,6 @@ For issues or feature requests:
 
 - [🐙 GitHub Issues](https://github.com/SloMR/pastepoint/issues)
 - [📧 sulaimanromaih@gmail.com](mailto:sulaimanromaih@gmail.com).
-
----
 
 ## 🔒 Security Considerations
 

--- a/client/angular.json
+++ b/client/angular.json
@@ -63,7 +63,7 @@
                 }
               ],
               "optimization": true,
-              "outputHashing": "all",
+              "outputHashing": "media",
               "sourceMap": false,
               "namedChunks": false,
               "aot": true,
@@ -94,7 +94,7 @@
                 }
               ],
               "optimization": true,
-              "outputHashing": "all",
+              "outputHashing": "media",
               "sourceMap": false,
               "aot": true,
               "namedChunks": false,


### PR DESCRIPTION
- Adds a detailed 'DISCLAIMER.md' document outlining the legal disclaimer for use of PastePoint.
- Includes the usage disclaimer link in the README file.
- Removes unnecessary row separations in the README file.
- Changes angular.json to update outputHashing from 'all' to 'media'.