### PR TITLE
Feat: Improv CORS

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1911,6 +1911,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "url",
  "uuid",
 ]
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -30,6 +30,7 @@ log = "0.4.27"
 rand = "0.9.1"
 bytes = "1.10.1"
 config = "0.15.11"
+url = "2.5.4"
 
 [dev-dependencies]
 actix-test = "0.1.5"

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -17,7 +17,7 @@ pub async fn index() -> impl Responder {
 // Create Session route
 // -----------------------------------------------------
 #[get("/create-session")]
-pub async fn create_session(store: web::Data<SessionStore>) -> impl Responder {
+pub async fn create_session(store: web::Data<SessionStore>) -> Result<HttpResponse, ServerError> {
     let code = SessionStore::generate_random_code(10);
     // Insert the new session without calling get_or_create_session_uuid.
     let new_uuid = Uuid::new_v4();

--- a/server/tests/origin_check_tests.rs
+++ b/server/tests/origin_check_tests.rs
@@ -1,0 +1,54 @@
+use actix_http::header::HeaderValue;
+use server::ServerConfig;
+
+#[test]
+fn test_check_origin_allowed() {
+    let mut config_https = ServerConfig::load(Some(false)).expect("load config");
+    config_https.cors_allowed_origins = "https://pastepoint.com".to_string();
+    let origin_https = HeaderValue::from_str("https://pastepoint.com").unwrap();
+    assert!(config_https.check_origin(&origin_https));
+
+    let mut config_http = ServerConfig::load(Some(false)).expect("load config");
+    config_http.cors_allowed_origins = "http://pastepoint.com".to_string();
+    let origin_http = HeaderValue::from_str("http://pastepoint.com").unwrap();
+    assert!(config_http.check_origin(&origin_http));
+}
+
+#[test]
+fn test_check_origin_allowed_www() {
+    let mut config_https = ServerConfig::load(Some(false)).expect("load config");
+    config_https.cors_allowed_origins = "https://www.pastepoint.com".to_string();
+    let origin_https = HeaderValue::from_str("https://www.pastepoint.com").unwrap();
+    assert!(config_https.check_origin(&origin_https));
+
+    let mut config_http = ServerConfig::load(Some(false)).expect("load config");
+    config_http.cors_allowed_origins = "http://www.pastepoint.com".to_string();
+    let origin_http = HeaderValue::from_str("http://www.pastepoint.com").unwrap();
+    assert!(config_http.check_origin(&origin_http));
+}
+
+#[test]
+fn test_check_origin_subdomain() {
+    let mut config_https = ServerConfig::load(Some(false)).expect("load config");
+    config_https.cors_allowed_origins = "https://pastepoint.com".to_string();
+    let origin_https = HeaderValue::from_str("https://sub.pastepoint.com").unwrap();
+    assert!(config_https.check_origin(&origin_https));
+
+    let mut config_http = ServerConfig::load(Some(false)).expect("load config");
+    config_http.cors_allowed_origins = "http://pastepoint.com".to_string();
+    let origin_http = HeaderValue::from_str("http://sub.pastepoint.com").unwrap();
+    assert!(config_http.check_origin(&origin_http));
+}
+
+#[test]
+fn test_check_origin_spoofed() {
+    let mut config_https = ServerConfig::load(Some(false)).expect("load config");
+    config_https.cors_allowed_origins = "https://pastepoint.com".to_string();
+    let origin_https = HeaderValue::from_str("https://pastepoint.com.evil.com").unwrap();
+    assert!(!config_https.check_origin(&origin_https));
+
+    let mut config_http = ServerConfig::load(Some(false)).expect("load config");
+    config_http.cors_allowed_origins = "http://pastepoint.com".to_string();
+    let origin_http = HeaderValue::from_str("http://pastepoint.com.evil.com").unwrap();
+    assert!(!config_http.check_origin(&origin_http));
+}


### PR DESCRIPTION
This pull request introduces changes to improve Cross-Origin Resource Sharing (CORS) handling in the server configuration, refactors related logic, and adds comprehensive tests to ensure correctness. The most notable updates include implementing a robust method for origin host extraction, modifying the `check_origin` logic, and adding unit tests for various CORS scenarios.

### CORS Handling Enhancements:
* [`server/src/config.rs`](diffhunk://#diff-7aec9b0ac22ce91dcf09989df83d30183914594644ba39fbff381977a4558b76R56-R71): Added a new helper function `extract_host` to parse and extract the host from the origin URL, supporting both standard and subdomain matching. Updated the `check_origin` method to use this function for more robust origin validation.

### Dependency Updates:
* [`server/Cargo.toml`](diffhunk://#diff-36a55fca956d2696a4fb89bc9847360169a01e70aa29641862a78ca833e9becfR33): Added the `url` crate as a dependency to facilitate URL parsing in the updated CORS logic.

### Route Refactoring:
* [`server/src/routes.rs`](diffhunk://#diff-c9e0690e8f2cc0fcfb723abb12bc8ba62362842d6c3a1adc526838a2b6d814fbL20-R20): Modified the `create_session` route to return a `Result` with a custom `ServerError` type for better error handling.

### Test Improvements:
* [`server/tests/basic_tests.rs`](diffhunk://#diff-7817d24969d8abebadc773c5643a9ed4ade806b72b45190ddeee098c05acc319L194-R197): Updated CORS-related tests to reflect the new `check_origin` logic, including adjustments for handling subdomains and protocol stripping. [[1]](diffhunk://#diff-7817d24969d8abebadc773c5643a9ed4ade806b72b45190ddeee098c05acc319L194-R197) [[2]](diffhunk://#diff-7817d24969d8abebadc773c5643a9ed4ade806b72b45190ddeee098c05acc319L218-R219) [[3]](diffhunk://#diff-7817d24969d8abebadc773c5643a9ed4ade806b72b45190ddeee098c05acc319L231-R235)
* [`server/tests/origin_check_tests.rs`](diffhunk://#diff-d7bd84372cfc858ee3b7bda8ceb8397facddd345036da0c04428fcb191bc3d3aR1-R54): Added unit tests for `check_origin` covering scenarios such as allowed origins, subdomains, and spoofed domains.