### PR TITLE
Client: Improves progress bar display and animation

### DIFF
--- a/client/src/app/features/chat/chat.component.css
+++ b/client/src/app/features/chat/chat.component.css
@@ -43,3 +43,8 @@
 .dark-scrollbar::-webkit-scrollbar-thumb:hover {
   background: #636e87;
 }
+
+/* Smooth width transition for progress bars */
+.progress-bar {
+  transition: width 0.3s ease-in-out;
+}

--- a/client/src/app/features/chat/chat.component.html
+++ b/client/src/app/features/chat/chat.component.html
@@ -457,7 +457,7 @@
                       {{ transfer.file.name | slice: 0 : 15 }}
                     </span>
                     <div class="flex items-center gap-1">
-                      <span class="text-xs text-secondary-500">{{ transfer.progress }}%</span>
+                      <span class="text-xs text-secondary-500">{{ transfer.progress | number:'1.0-0' }}%</span>
                       <button
                         (click)="
                           $event.stopPropagation(); $event.preventDefault(); cancelUpload(transfer)
@@ -479,8 +479,8 @@
                   </div>
                   <div class="w-full rounded-full bg-secondary-200 h-1.5 dark:bg-secondary-700">
                     <div
-                      class="rounded-full bg-primary-600 h-1.5"
-                      [style.width]="transfer.progress + '%'"
+                      class="rounded-full bg-primary-600 h-1.5 progress-bar"
+                      [style.width.%]="transfer.progress"
                     ></div>
                   </div>
                 </div>
@@ -492,7 +492,7 @@
                       {{ download.fileName | slice: 0 : 15 }}
                     </span>
                     <div class="flex items-center gap-1">
-                      <span class="text-xs text-secondary-500"> {{ download.progress }}% </span>
+                      <span class="text-xs text-secondary-500"> {{ download.progress | number:'1.0-0' }}% </span>
                       <button
                         (click)="
                           $event.stopPropagation();
@@ -516,8 +516,8 @@
                   </div>
                   <div class="w-full rounded-full bg-secondary-200 h-1.5 dark:bg-secondary-700">
                     <div
-                      class="rounded-full bg-success-600 h-1.5"
-                      [style.width]="download.progress + '%'"
+                      class="rounded-full bg-success-600 h-1.5 progress-bar"
+                      [style.width.%]="download.progress"
                     ></div>
                   </div>
                 </div>
@@ -930,7 +930,7 @@
                       {{ transfer.file.name | slice: 0 : 15 }}
                     </span>
                     <div class="flex items-center gap-1">
-                      <span class="text-xs text-secondary-500">{{ transfer.progress }}%</span>
+                      <span class="text-xs text-secondary-500">{{ transfer.progress | number:'1.0-0' }}%</span>
                       <button
                         (click)="
                           $event.stopPropagation(); $event.preventDefault(); cancelUpload(transfer)
@@ -952,8 +952,8 @@
                   </div>
                   <div class="w-full rounded-full bg-secondary-200 h-1.5 dark:bg-secondary-700">
                     <div
-                      class="rounded-full bg-primary-600 h-1.5"
-                      [style.width]="transfer.progress + '%'"
+                      class="rounded-full bg-primary-600 h-1.5 progress-bar"
+                      [style.width.%]="transfer.progress"
                     ></div>
                   </div>
                 </div>
@@ -965,7 +965,7 @@
                       {{ download.fileName | slice: 0 : 15 }}
                     </span>
                     <div class="flex items-center gap-1">
-                      <span class="text-xs text-secondary-500"> {{ download.progress }}% </span>
+                      <span class="text-xs text-secondary-500"> {{ download.progress | number:'1.0-0' }}% </span>
                       <button
                         (click)="
                           $event.stopPropagation();
@@ -989,8 +989,8 @@
                   </div>
                   <div class="w-full rounded-full bg-secondary-200 h-1.5 dark:bg-secondary-700">
                     <div
-                      class="rounded-full bg-success-600 h-1.5"
-                      [style.width]="download.progress + '%'"
+                      class="rounded-full bg-success-600 h-1.5 progress-bar"
+                      [style.width.%]="download.progress"
                     ></div>
                   </div>
                 </div>


### PR DESCRIPTION
This pull request introduces improvements to the `chat.component.html` and `chat.component.css` files, focusing on enhancing progress bar functionality and display consistency. The changes include adding smooth transitions for progress bars, updating percentage formatting for better readability, and modifying progress bar width binding for cleaner syntax.

### Progress Bar Enhancements:
* [`client/src/app/features/chat/chat.component.css`](diffhunk://#diff-c7ddbe6af06e1a5265dce75935bf4b1847c9b6b7e7c4125b99b3abd8119aa8b9R46-R50): Added smooth width transition for progress bars using a CSS rule for `.progress-bar`.
* [`client/src/app/features/chat/chat.component.html`](diffhunk://#diff-fb927dce0e6c1d1219abfafff0f4f547c682bbce8640ef3b7bf921aadcad8063L482-R483): Updated progress bar width binding to use `[style.width.%]="progress"` for cleaner and more Angular-friendly syntax. Applied this change to both upload and download progress bars. [[1]](diffhunk://#diff-fb927dce0e6c1d1219abfafff0f4f547c682bbce8640ef3b7bf921aadcad8063L482-R483) [[2]](diffhunk://#diff-fb927dce0e6c1d1219abfafff0f4f547c682bbce8640ef3b7bf921aadcad8063L519-R520) [[3]](diffhunk://#diff-fb927dce0e6c1d1219abfafff0f4f547c682bbce8640ef3b7bf921aadcad8063L955-R956) [[4]](diffhunk://#diff-fb927dce0e6c1d1219abfafff0f4f547c682bbce8640ef3b7bf921aadcad8063L992-R993)

### Percentage Display Improvements:
* [`client/src/app/features/chat/chat.component.html`](diffhunk://#diff-fb927dce0e6c1d1219abfafff0f4f547c682bbce8640ef3b7bf921aadcad8063L460-R460): Updated percentage formatting to use Angular's `number` pipe (`number:'1.0-0'`) for consistent display of whole numbers. Applied this change to upload and download progress indicators. [[1]](diffhunk://#diff-fb927dce0e6c1d1219abfafff0f4f547c682bbce8640ef3b7bf921aadcad8063L460-R460) [[2]](diffhunk://#diff-fb927dce0e6c1d1219abfafff0f4f547c682bbce8640ef3b7bf921aadcad8063L495-R495) [[3]](diffhunk://#diff-fb927dce0e6c1d1219abfafff0f4f547c682bbce8640ef3b7bf921aadcad8063L933-R933) [[4]](diffhunk://#diff-fb927dce0e6c1d1219abfafff0f4f547c682bbce8640ef3b7bf921aadcad8063L968-R968)