### PR TITLE
Bump build Client (0.10.0)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "0.9.9",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.9.9",
+      "version": "0.10.0",
       "dependencies": {
         "@angular/animations": "^19.2.14",
         "@angular/cdk": "^19.2.19",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.9.9",
+  "version": "0.10.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",


### PR DESCRIPTION
This pull request updates the version of the `client` package from `0.9.9` to `0.10.0`. The changes are reflected in both the `package-lock.json` and `package.json` files.

Version update:

* [`client/package-lock.json`](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL3-R9): Updated the `version` field from `0.9.9` to `0.10.0`.
* [`client/package.json`](diffhunk://#diff-1846122c2c83a486a3693f7966aa522c34cf489f674185c4da0d9221683fd81fL3-R3): Updated the `version` field from `0.9.9` to `0.10.0`.